### PR TITLE
Oh python

### DIFF
--- a/cronenberg/model/web.py
+++ b/cronenberg/model/web.py
@@ -141,10 +141,10 @@ class JumbotronSingleStat(SingleStat):
         return cls(**d)
 
 class ChartPresentation(Presentation):
-    def __init__(self, title='', options={}, interactive=True, **kwargs):
+    def __init__(self, title='', options=None, interactive=True, **kwargs):
         super(ChartPresentation, self).__init__(**kwargs)
         self.title = title
-        self.options = options
+        self.options = options or {}
         self.interactive = interactive
 
 class DonutChart(ChartPresentation):


### PR DESCRIPTION
The “All the y-axis labels are the same” bug wasn’t a javascript
scoping issue, it was a python issue. Using a dict literal as a default
value for a constructor kwarg is a bad idea.
