### PR TITLE
Cleaning up the interactive chart flag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,6 @@ module.exports = function(grunt) {
           'js/charts/graphite.js',
           'js/charts/nvd3.js',
           'js/charts/flot.js',
-          'js/charts/impl.js',
           'js/app/actions.js',
           'js/models/**/*.js',
           'js/extensions/**/*.js',

--- a/js/app/manager.js
+++ b/js/app/manager.js
@@ -102,7 +102,6 @@ ds.manager =
       dashboard.visit(function(item) {
         if (!item.item_type)
           return
-        item.interactive = interactive
         if (item.requires_data) {
           holder.raw_data_required = true
         }
@@ -178,6 +177,7 @@ ds.manager =
             interactive = context.interactive
           }
           holder.raw_data_required = interactive
+          ds.charts.interactive = interactive
 
           // Build a map from the presentation elements to their
           // model objects.
@@ -272,6 +272,11 @@ ds.manager =
 
       dashboard.definition.queries = result.get_queries() // this could go in an observer
       dashboard.set_items([result])
+
+      // Disable existing query handlers
+      for (var k in dashboard.definition.queries) {
+        dashboard.definition.queries[k].off()
+      }
 
       $('#' + dashboard.definition.item_id).replaceWith(dashboard.render())
       dashboard.load_all()

--- a/js/charts.js
+++ b/js/charts.js
@@ -16,44 +16,53 @@ ds.charts =
   (function () {
 
     var self = limivorous.observable()
-               .property('impl')
-               .build()
+                         .property('provider')
+                         .property('interactive', {init: false})
+                         .build()
 
     self.DEFAULT_PALETTE = 'spectrum6'
+
+    function get_renderer(fn_name, item) {
+      var interactive = self.interactive
+      if ((typeof(item) !== 'undefined') && (typeof(item.interactive) !== 'undefined'))
+        interactive = item.interactive
+      return interactive ? self.provider[fn_name] : ds.charts.graphite[fn_name]
+    }
 
     /**
      * Render a minimal line chart into element.
      */
     self.simple_line_chart = function(element, item, query) {
-      return self.impl.simple_line_chart(element, item, query)
+      return get_renderer('simple_line_chart', item)(element, item, query)
     }
 
     /**
      * Render a complete line chart into element.
      */
     self.standard_line_chart = function(element, item, query) {
-      return self.impl.standard_line_chart(element, item, query)
+      return get_renderer('standard_line_chart', item)(element, item, query)
     }
 
     /**
      * Render a minimal area chart into element.
      */
     self.simple_area_chart = function(element, item, query) {
-      return self.impl.simple_area_chart(element, item, query)
+      return get_renderer('simple_area_chart', item)(element, item, query)
     }
 
     /**
      * Render a complete area chart into element.
      */
     self.stacked_area_chart = function(element, item, query) {
-      return self.impl.stacked_area_chart(element, item, query)
+      return get_renderer('stacked_area_chart', item)(element, item, query)
     }
 
     /**
      * Render a donut/pie chart into element.
      */
     self.donut_chart = function(element, item, query) {
-      return self.impl.donut_chart(element, item, query)
+      // TODO: donut/pie charts don't have a graphite renderer yet
+      return self.provider.donut_chart(element, item, query)
     }
 
     /**
@@ -67,7 +76,7 @@ ds.charts =
       if (type) {
         return ds.charts[type].process_series(series)
       }
-      return self.impl.process_series(series)
+      return self.provider.process_series(series)
     }
 
     /**

--- a/js/charts/impl.js
+++ b/js/charts/impl.js
@@ -1,1 +1,0 @@
-ds.charts.impl = ds.charts.nvd3

--- a/js/charts/nvd3.js
+++ b/js/charts/nvd3.js
@@ -160,6 +160,7 @@ ds.charts.nvd3 =
     }
 
     self.donut_chart = function(e, item, query) {
+      console.log('nvd3.donut_chart: ' + item.item_id + '/' + item.item_type + ': ' + query.name)
       var options = item.options || {}
       var transform = item.transform || 'sum'
       var series = query.chart_data('nvd3')
@@ -214,3 +215,8 @@ ds.charts.nvd3 =
 
     return self
 })()
+
+/**
+ * Set NVD3 as the default chart provider.
+ */
+ds.charts.provider = ds.charts.nvd3

--- a/js/models/dashboard.js
+++ b/js/models/dashboard.js
@@ -55,7 +55,6 @@ ds.models.dashboard = function(data) {
     })
   }
 
-
   self.update_index = function() {
     var index = self.index = {}
     self.visit(function(item) {

--- a/js/models/data/Query.js
+++ b/js/models/data/Query.js
@@ -105,6 +105,13 @@ ds.models.data.Query = function(data_) {
   }
 
   /**
+   * Remove all registered event handlers.
+   */
+  self.off = function() {
+    bean.off(self, 'ds-data-ready')
+  }
+
+  /**
    * Process the results of executing the query, transforming
    * the returned structure into something consumable by the
    * charting library, and calculating sums.

--- a/templates/models/donut_chart.js
+++ b/templates/models/donut_chart.js
@@ -1,4 +1,4 @@
 ds.templates.models.donut_chart.dataHandler =
     function(query, item) {
-        var chart = ds.charts.donut_chart($("#" + item.item_id + ' .ds-graph-holder'), item, query);
-    };
+        ds.charts.donut_chart($("#" + item.item_id + ' .ds-graph-holder'), item, query)
+    }

--- a/templates/models/simple_time_series.js
+++ b/templates/models/simple_time_series.js
@@ -1,12 +1,4 @@
 ds.templates.models.simple_time_series.dataHandler =
     function(query, item) {
-        var element = $('#' + item.item_id + ' .ds-graph-holder')
-        var renderer = item.interactive
-            ? ds.charts
-            : ds.charts.graphite
-        if (item.filled) {
-            renderer.simple_area_chart(element, item, query)
-        } else {
-            renderer.simple_line_chart(element, item, query)
-        }
+        ds.charts.simple_area_chart($('#' + item.item_id + ' .ds-graph-holder'), item, query)
     }

--- a/templates/models/singlegraph.js
+++ b/templates/models/singlegraph.js
@@ -1,21 +1,12 @@
 ds.templates.models.singlegraph.dataHandler =
     function(query, item) {
-        if (!item.interactive) {
-            var element = $('#' + item.item_id + ' .ds-graph-holder');
-            var png_url = ds.charts.graphite.chart_url(item, {
-                height: element.height(),
-                width: element.width()
-            });
-            element.html($('<img/>').attr('src', png_url));
-        } else {
-            ds.charts.simple_area_chart($("#" + item.item_id + ' .ds-graph-holder'), item, query);
-        }
-        item.options.margin = { top: 0, left: 0, bottom: 0, right: 0 };
-        var label = query.data[item.index || 0].key;
-        var value = query.summation[item.transform];
+        ds.charts.simple_area_chart($("#" + item.item_id + ' .ds-graph-holder'), item, query)
+        item.options.margin = { top: 0, left: 0, bottom: 0, right: 0 }
+        var label = query.data[item.index || 0].key
+        var value = query.summation[item.transform]
         if (item.index) {
-            value = query.data[item.index].summation[item.transform];
+            value = query.data[item.index].summation[item.transform]
         }
-        $('#' + item.item_id + ' span.value').text(d3.format(item.format)(value));
-        $('#' + item.item_id + ' span.ds-label').text(label);
-    };
+        $('#' + item.item_id + ' span.value').text(d3.format(item.format)(value))
+        $('#' + item.item_id + ' span.ds-label').text(label)
+    }

--- a/templates/models/stacked_area_chart.js
+++ b/templates/models/stacked_area_chart.js
@@ -1,7 +1,4 @@
 ds.templates.models.stacked_area_chart.dataHandler =
-  function(query, item) {
-      var renderer = item.interactive
-          ? ds.charts
-          : ds.charts.graphite
-      renderer.stacked_area_chart($('#' + item.item_id + ' .ds-graph-holder'), item, query)
-  }
+    function(query, item) {
+        ds.charts.stacked_area_chart($('#' + item.item_id + ' .ds-graph-holder'), item, query)
+    }

--- a/templates/models/standard_time_series.js
+++ b/templates/models/standard_time_series.js
@@ -1,7 +1,4 @@
 ds.templates.models.standard_time_series.dataHandler =
-  function(query, item) {
-      var renderer = item.interactive
-          ? ds.charts
-          : ds.charts.graphite
-      renderer.standard_line_chart($('#' + item.item_id + ' .ds-graph-holder'), item, query)
-  }
+    function(query, item) {
+        ds.charts.standard_line_chart($('#' + item.item_id + ' .ds-graph-holder'), item, query)
+    }


### PR DESCRIPTION
- The item.interactive flag still exists, but is now purely an override
- ds.charts.interactive is the main flag
- dispatching between interactive renderer & graphite renderer is
  handled in ds.charts; the item dataHandler event handlers no longer
  need to do that

Cleans up some of the chart code in prep for item #120 
