### PR TITLE
Fixed a bug in the graphite importer

### DIFF
--- a/tessera/importer/graphite.py
+++ b/tessera/importer/graphite.py
@@ -31,18 +31,27 @@ class GraphiteDashboardImporter(object):
         log.info('Found {0} dashboards to import'.format(len(names)))
         log.info(','.join(names))
 
+        imported = 0
+        skipped = 0
+        updated = 0
+
         for name in names:
             href = self.__graphite_href(name)
             dashboard = database.Dashboard.query.filter_by(imported_from=href).first()
             if dashboard and (not overwrite):
                 log.info('Skipping {0}'.format(name))
+                skipped += 1
                 continue
             elif dashboard and overwrite:
                 log.info('Updating {0}'.format(name))
+                updated += 1
             else:
                 log.info('Importing {0}'.format(name))
+                imported += 1
             dash = self.import_dashboard(name, dash=dashboard, **kwargs)
             mgr.store_dashboard(dash)
+
+        log.info('Imported {0} new dashboards; updated {1}; skipped {2}'.format(imported, updated, skipped))
 
     def __graphite_href(self, name):
         return '{0}/dashboard/{1}'.format(app.config['GRAPHITE_URL'], urllib.quote(name))
@@ -70,18 +79,19 @@ class GraphiteDashboardImporter(object):
         #         num_columns = 1
         #         span = 12
 
+        graph_count = 0
         row = Row()
         for graph in graphite_dashboard['graphs']:
             # Graphite's dashboard API is so redundant. Each graph is
             # a 3-element array:
             # [
-            #    targets array,
+            #    target string,
             #    options dict (which contains the targets array too),
             #    render URL string
             #  ]
             targets, options, render_url = graph
             presentation = None
-            stacked_p = render_url.find('stacked') != -1 or options.get('areaMode', None) == 'stacked'
+            stacked_p = (render_url.find('stacked')) != -1 or (options.get('areaMode', None) == 'stacked')
             query = 'q' + str(len(definition.queries))
             targets = options.get('target', [])
             definition.queries[query] = targets[0] if len(targets) == 1 else targets
@@ -99,9 +109,16 @@ class GraphiteDashboardImporter(object):
             presentation.options['margin'] = { 'top' : 16, 'left' : 80, 'right' : 0, 'bottom' : 16}
 
             row.items.append(Cell(span=span, items=presentation))
+            graph_count += 1
             if len(row.items) == columns:
                 section.items.append(row)
                 row = Row()
+
+        if len(row.items) > 0:
+            section.items.append(row)
+
+        if graph_count == 0:
+            log.warn('Failed to convert any graphs for dashboard {0}'.format(name))
 
         dashboard.definition = database.DashboardDef(definition=dumps(definition))
         return dashboard


### PR DESCRIPTION
If there were fewer graphs than the number of graphs per row, the row
wouldn’t get added to the dashboard, and you end up with an empty
imported dashboard.
