### PR TITLE
Expand query templates on edit

### DIFF
--- a/js/app/handlers/edit-mode.js
+++ b/js/app/handlers/edit-mode.js
@@ -72,6 +72,7 @@
             var target = newValue.trim().replace(new RegExp('\r?\n','g'), '')
             var query = ds.manager.current.dashboard.definition.queries[query_name]
             query.targets = [target]
+            query.render_templates(ds.manager.location_context())
             query.load()
           }
         })

--- a/js/app/manager.js
+++ b/js/app/manager.js
@@ -112,20 +112,16 @@ ds.manager =
     }
 
     /**
-     * Set up us the API call.
+     * Return a context object based on the current URL.
      */
-    self._prep_url = function(base_url, options) {
-      var url = URI(base_url).setQuery('rendering', true)
-      var context = url.query(true)
+    self.location_context = function(context) {
+      var context = context || {}
       var params = URI(window.location).query(true)
       var variables = {}
-      context.from = context.from || params.from || options.from || '-3h'
-      context.until = context.until || params.until || options.until
 
-      url.setQuery('from', context.from)
-      if (context.until) {
-        url.setQuery('until', context.until)
-      }
+      context.from = params.from || '-3h'
+      context.until = params.until
+
       for (var key in params) {
         /* compatibility w/gdash params */
         if (key.indexOf('p[') == 0) {
@@ -135,15 +131,35 @@ ds.manager =
           variables[key] = params[key]
         }
       }
-      context.url = url.href()
       context.variables = variables
       context.params = params
 
+      return context
+    }
+
+    /**
+     * Set up us the API call.
+     */
+    self._prep_url = function(base_url, options) {
+      var url = URI(base_url).setQuery('rendering', true)
+      var context = self.location_context(url.query(true))
+
+      context.from = options.from || context.from
+      context.until = context.until || options.until
+
+      url.setQuery('from', context.from)
+      if (context.until) {
+        url.setQuery('until', context.until)
+      }
+
+      context.url = url.href()
+
       if (typeof(options.interactive) != 'undefined') {
         context.interactive = options.interactive
-      } else if (params.interactive) {
-        context.interactive = params.interactive != 'false'
+      } else if (context.params.interactive) {
+        context.interactive = context.params.interactive != 'false'
       }
+
       return context
     }
 

--- a/js/models/data/Query.js
+++ b/js/models/data/Query.js
@@ -3,6 +3,7 @@ ds.models.data.Query = function(data_) {
 
   var self = limivorous.observable()
                        .property('targets')
+                       .property('expanded_targets')
                        .property('name')
                        .property('data')
                        .property('summation')
@@ -25,9 +26,9 @@ ds.models.data.Query = function(data_) {
   Object.defineProperty(self, 'is_query', {value: true})
 
   self.render_templates = function(context) {
-    self.targets = self.targets.map(function(t) {
-                     return ds.render_template(t, context)
-                   })
+    self.expanded_targets = self.targets.map(function(t) {
+                              return ds.render_template(t, context)
+                            })
   }
 
   self.url = function(_) {
@@ -39,8 +40,9 @@ ds.models.data.Query = function(data_) {
     if (self.options.until) {
       url.setQuery('until', self.options.until)
     }
-    for (var i in self.targets) {
-      url.addQuery('target', self.targets[i])
+    var targets = self.expanded_targets || self.targets
+    for (var i in targets) {
+      url.addQuery('target', targets[i])
     }
     return url.href()
   }


### PR DESCRIPTION
- Added `expanded_targets` attribute to Query to store rendered
  targets
- Refactored part of `ds.manager._prep_url()` into a public function
  to generate the base template context from the current window location
- Expand queries after editing

Fixes bug #123 
