### PR TITLE
Strip newlines from query targets before evaluation

### DIFF
--- a/js/models/data/Query.js
+++ b/js/models/data/Query.js
@@ -50,7 +50,7 @@ ds.models.data.Query = function(data) {
     }
     var targets = self.expanded_targets || self.targets
     for (var i in targets) {
-      url.addQuery('target', targets[i])
+      url.addQuery('target', targets[i].replace(/(\r\n|\n|\r)/gm,""))
     }
     return url.href()
   }


### PR DESCRIPTION
Allows newlines to be existent & preserved in the stored definition,
for readability. Implements issue #190 
