### PR TITLE
Timeshift table rendering tweaks

### DIFF
--- a/js/models/data/Summation.js
+++ b/js/models/data/Summation.js
@@ -61,8 +61,6 @@ ds.models.data.Summation = function(initial_data) {
   } else if (typeof(initial_data) === 'object') {
     self.sum = initial_data.sum || self.sum
     self.min = initial_data.min || self.min
-    if (0.01 > self.min > -0.01)
-      self.min = 0
     self.max = initial_data.max || self.max
     self.first = initial_data.first || self.first
     self.last = initial_data.last || self.last
@@ -75,12 +73,12 @@ ds.models.data.Summation = function(initial_data) {
    */
   self.subtract = function(other) {
     return ds.models.data.Summation({
-      sum: self.sum - other.sum,
-      min: self.min - other.min,
-      max: self.max - other.max,
-      mean: self.mean- other.mean,
+      sum:   self.sum   - other.sum,
+      min:   self.min   - other.min,
+      max:   self.max   - other.max,
+      mean:  self.mean  - other.mean,
       first: self.first - other.first,
-      last: self.last - other.last,
+      last:  self.last  - other.last,
       count: self.count
     })
   }

--- a/templates/models/timeshift_summation_table_body.hbs
+++ b/templates/models/timeshift_summation_table_body.hbs
@@ -3,10 +3,10 @@
   <th>Average</th>
   <td>{{format item.format now.mean}}</td>
   <td>{{format item.format then.mean}}</td>
-  <td class="{{#if diff.mean_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.mean_class}}">
     {{format item.format diff.mean}}
   </td>
-  <td class="{{#if diff.mean_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.mean_class}}">
     {{diff.mean_pct}}
   </td>
 </tr>
@@ -14,10 +14,10 @@
   <th>Min</th>
   <td>{{format item.format now.min}}</td>
   <td>{{format item.format then.min}}</td>
-  <td class="{{#if diff.min_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.min_class}}">
     {{format item.format diff.min}}
   </td>
-  <td class="{{#if diff.min_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.min_class}}">
     {{diff.min_pct}}
   </td>
 </tr>
@@ -25,10 +25,10 @@
   <th>Max</th>
   <td>{{format item.format now.max}}</td>
   <td>{{format item.format then.max}}</td>
-  <td class="{{#if diff.max_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.max_class}}">
     {{format item.format diff.max}}
   </td>
-  <td class="{{#if diff.max_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.max_class}}">
     {{diff.max_pct}}
   </td>
 </tr>
@@ -36,10 +36,10 @@
   <th>Sum</th>
   <td>{{format item.format now.sum}}</td>
   <td>{{format item.format then.sum}}</td>
-  <td class="{{#if diff.sum_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.sum_class}}">
     {{format item.format diff.sum}}
   </td>
-  <td class="{{#if diff.sum_positive}}ds-diff-plus{{else}}ds-diff-minus{{/if}}">
+  <td class="{{diff.sum_class}}">
     {{diff.sum_pct}}
   </td>
 </tr>

--- a/tessera/static/tessera.css
+++ b/tessera/static/tessera.css
@@ -328,22 +328,24 @@ td.ds-tooltip-value {
     text-align: right;
 }
 
-/*
+
 td.ds-diff-plus::before {
     content: "+";
+    font-weight: bold;
 }
 td.ds-diff-minus::before {
     content: "-";
-}
-*/
-
-td.ds-diff-plus {
-    color: green;
     font-weight: bold;
 }
-
+td.ds-diff-plus {
+    color: green;
+}
 td.ds-diff-minus {
     color: red;
+}
+.ds-timeshift-summation-table tbody td,
+.ds-timeshift-summation-table thead th {
+    text-align: right;
 }
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
- Making the “+/-“ indicators more visually obvious for accessiblity.
  Supplied by CSS so they can be independently styled and are slightly
  separated from the numbers.
- Adding in “+” indicators
- double math is fuzzy. wheee. Let’s do those margins better
