### PR TITLE
Slight modifications to allow running on python 3

### DIFF
--- a/tessera/application.py
+++ b/tessera/application.py
@@ -28,4 +28,4 @@ if os.environ.get('TESSERA_CONFIG', False):
 
 db = SQLAlchemy(app)
 
-from views import *
+from .views import *

--- a/tessera/importer/graphite.py
+++ b/tessera/importer/graphite.py
@@ -24,7 +24,7 @@ class GraphiteDashboardImporter(object):
 
     def dump_dashboards(self, query):
         names = self.get_dashboard_names(query)
-        print json.dumps([ self.get_dashboard(n) for n in names ], cls=EntityEncoder, indent=4)
+        print(json.dumps([ self.get_dashboard(n) for n in names ], cls=EntityEncoder, indent=4))
 
     def import_dashboards(self, query, overwrite=False, **kwargs):
         names = self.get_dashboard_names(query)

--- a/tessera/model/web.py
+++ b/tessera/model/web.py
@@ -399,7 +399,7 @@ class DashboardDefinition(DashboardContainer):
         for name in self.queries.keys():
             query = self.queries[name]
             if isinstance(query, dict):
-                for key in query.keys():
+                for key in list(query.keys()):
                     if key not in [ 'targets', 'name' ]:
                         del query[key]
 

--- a/tessera/views.py
+++ b/tessera/views.py
@@ -295,7 +295,7 @@ def api_dashboard_update_definition(id):
         raise _set_exception_response(e)
 
     # Validate the payload
-    definition = DashboardDefinition.from_json(json.loads(request.data))
+    definition = DashboardDefinition.from_json(json.loads(request.data.decode('utf-8')))
 
     if dashboard.definition:
         dashboard.definition.definition = dumps(definition)
@@ -387,7 +387,7 @@ def _render_client_side_dashboard(dashboard, template='dashboard.html', transfor
     from_time = _get_param('from', app.config['DEFAULT_FROM_TIME'])
     until_time = _get_param('until', None)
     title = '{0} {1}'.format(dashboard.category, dashboard.title)
-    print '_render_client_side_dashboard: transform={0}'.format(transform)
+    print('_render_client_side_dashboard: transform={0}'.format(transform))
     return _render_template(template,
                             dashboard=dashboard,
                             definition=dashboard.definition,
@@ -451,7 +451,7 @@ def ui_dashboard_with_slug(id, slug, path):
 
 @app.route('/dashboards/<id>/')
 def ui_dashboard(id, slug=None, path=None):
-    print 'ui_dashboard(): id={0}, slug={1}, path={2}'.format(id, slug, path)
+    print('ui_dashboard(): id={0}, slug={1}, path={2}'.format(id, slug, path))
     transform = None
     if path and path.find('transform') > -1:
         element, ignore, name = path.split('/')


### PR DESCRIPTION
It'd be nice if the project could support python 2 and 3 from the beginning :)

I've been trying this with graphite-api and got it working just fine, only made these changes as I found python3 incompatibilities. Everything should still work on Python 2.

Ideally these `print`s should be replaced with proper logging calls or `sys.stdout.write`…
