### PR TITLE
For fiddling with id allocation

### DIFF
--- a/js/app/handlers/edit-mode.js
+++ b/js/app/handlers/edit-mode.js
@@ -219,9 +219,9 @@
     handler: function(action, item) {
       var dashboard = ds.manager.current.dashboard
       var parent = dashboard.find_parent(item)
-      var dup = ds.models.factory(item.toJSON())
+      var dup = ds.models.factory(item.toJSON()).set_item_id(null)
       dup.visit(function(child) {
-        child.item_id = undefined
+        child.item_id = null
       })
       parent.add_after(item, dup)
       dashboard.update_index()

--- a/js/models/dashboard.js
+++ b/js/models/dashboard.js
@@ -28,7 +28,7 @@ ds.models.dashboard = function(data) {
                          }
                        })
                        .build()
-  , next_id = 0
+    , next_id = 0
 
   self.index = {}
 
@@ -57,22 +57,22 @@ ds.models.dashboard = function(data) {
   }
 
   self.update_index = function() {
-    var index = self.index = {}
+    var index = {}
     self.visit(function(item) {
       if (item.is_dashboard_item) {
         if ( !item.item_id ) {
           item.item_id = self.next_id()
         }
-        if (self.index[item.item_id]) {
+        if (index[item.item_id]) {
           console.log('ERROR: item_id + ' + item.item_id + ' is already indexed.')
         }
         index[item.item_id] = item
         item.set_dashboard(self)
       }
     })
+    self.index = index
     return self
   }
-
 
   if (data) {
     self.set_id(data.id)


### PR DESCRIPTION
- in update_index(), build the new index first, then assign to
  self.index in one swell foop
- dup.visit() should visit itself, but set the dup’s item_id to null
  anyway to be sure

Fixes #228 
