### PR TITLE
Move time shift logic to Query

### DIFF
--- a/js/models/dashboard-items/timeshift_summation_table.js
+++ b/js/models/dashboard-items/timeshift_summation_table.js
@@ -23,7 +23,10 @@ ds.register_dashboard_item('timeshift_summation_table', {
     Object.defineProperty(self, 'requires_data', {value: true})
 
     function update_query() {
-      self.query_override = shift_query(self.query, self)
+      if (self.query && self.query.is_query) {
+        self.query_override =
+          self.query.join(self.query.shift(self.shift)).set_name(self.item_id + '_shifted')
+      }
     }
 
     if (data) {
@@ -37,27 +40,8 @@ ds.register_dashboard_item('timeshift_summation_table', {
       update_query()
     }).on('change:dashboard', function(e) {
       update_query()
-    }).on('change:query_override', function(e) {
-      //ds.manager.update_item_view(self)
     })
     ds.models.item.init(self, data)
-
-    function shift_query(input, item) {
-      if (input && input.is_query) {
-        var targets = input.targets
-        if (!targets)
-          return undefined
-        var group = 'group(' + input.targets.join(',') + ')'
-        return ds.models.data.Query()
-               .set_name(item.item_id + '_shift_' + input.name)
-               .set_targets([
-                 group,
-                 'timeShift(' + group + ', \"' + item.shift + '\")'
-               ])
-      } else {
-        return undefined
-      }
-    }
 
     self.toJSON = function() {
       var data = ds.models.item.json(self)

--- a/js/models/data/Query.js
+++ b/js/models/data/Query.js
@@ -137,6 +137,41 @@ ds.models.data.Query = function(data) {
     bean.off(self, 'ds-data-ready')
   }
 
+  function group_targets(query) {
+    return (query.targets.length > 1)
+         ? 'group(' + query.targets.join(',') + ')'
+         : query.targets[0]
+  }
+
+  /**
+   * Return a new query with the targets timeshifted.
+   */
+  self.shift = function(interval) {
+    var group = group_targets(self)
+    return ds.models.data.Query({
+      name: self.name + '_shift_' + interval,
+      targets: [
+        'timeShift(' + group + ', \"' + interval + '\")'
+      ]
+    })
+  }
+
+  /**
+   * Return a new query with the targets from this query and another
+   * query joined into a 2-target array, for comparison presentations.
+   */
+  self.join = function(other) {
+    var target_self  = group_targets(self)
+    var target_other = group_targets(other)
+    return ds.models.data.Query({
+      name: self.name + '_join_' + other.name,
+      targets: [
+        target_self,
+        target_other
+      ]
+    })
+  }
+
   /**
    * Process the results of executing the query, transforming
    * the returned structure into something consumable by the
@@ -151,6 +186,11 @@ ds.models.data.Query = function(data) {
     return self
   }
 
+  /**
+   * Fetch data processed for use by a particular chart renderer, and
+   * cache it in the query object so it's not re-processed over and
+   * over.
+   */
   self.chart_data = function(type) {
     var attribute = 'chart_data_' + type
     if (typeof(self[attribute]) === 'undefined') {

--- a/js/models/transform/TimeShift.js
+++ b/js/models/transform/TimeShift.js
@@ -58,16 +58,11 @@ ds.transforms.register({
 
     for (var i in shifts) {
       var shift = shifts[i]
-      var modified_query = ds.models.data.Query(query.toJSON())
-                             .set_name(query.name + '/' + shift.shift)
-                             .set_targets(query.targets.map(function(target) {
-                                            return 'timeShift(' + target + ', "' + shift.shift + '")'
-                                          }))
-
-      var modified_item = make(item.toJSON())
-                                   .set_item_id(undefined)
-                                   .set_query(modified_query)
-                                   .set_title(shift.title)
+      var modified_query = query.shift(shift.shift)
+      var modified_item  = make(item.toJSON())
+                                    .set_item_id(undefined)
+                                    .set_query(modified_query)
+                                    .set_title(shift.title)
       section.add(make_row(modified_query, modified_item))
     }
 


### PR DESCRIPTION
Move query modifications to the Query model so we can reuse them. Still
confused about graphite’s timeShift() behavior; seems to fail in graphs
in places it works fine if the response format is JSON
