### PR TITLE
Per-item actions for timeshift

### DIFF
--- a/js/action.js
+++ b/js/action.js
@@ -28,6 +28,17 @@ ds.action = function(data) {
     self.category = data.category
   }
 
+  self.toJSON = function() {
+    return {
+      name: self.name,
+      category: self.category,
+      show: self.show,
+      hide: self.hide,
+      class: self.class,
+      options: self.options
+    }
+  }
+
   return self
 }
 

--- a/js/app/handlers/edit-mode.js
+++ b/js/app/handlers/edit-mode.js
@@ -107,7 +107,7 @@
           var target = newValue.trim()
           var query = ds.manager.current.dashboard.definition.queries[query_name]
           query.targets = [target]
-          query.render_templates(ds.manager.location_context())
+          query.render_templates(ds.context().variables)
           query.load()
         }
       })

--- a/js/app/handlers/menu-presentation-actions.js
+++ b/js/app/handlers/menu-presentation-actions.js
@@ -73,7 +73,7 @@ $(document).on('click', 'ul.ds-action-menu li', function(event) {
   var presentation_id = $(this).parent().parent().parent().parent().parent()[0].id
   var item = ds.manager.current.dashboard.get_item(presentation_id)
 
-  var action = ds.actions.get('presentation-actions', this.getAttribute('data-ds-action'))
+  var action = ds.actions.get(this.getAttribute('data-ds-category'), this.getAttribute('data-ds-action'))
   action.handler(action, item)
 
   /* prevents resetting scroll position */

--- a/js/app/helpers.js
+++ b/js/app/helpers.js
@@ -125,14 +125,17 @@ Handlebars.registerHelper('interactive_property', function(property, item) {
   return new Handlebars.SafeString(property.render(item))
 })
 
-
 Handlebars.registerHelper('actions', function(category, type) {
   var template = ds.templates.action
   if (type === 'button') {
     template = ds.templates.action_button
   }
   var actions = ds.actions.list(category)
-  if (actions && (actions instanceof Array)) {
+  if (actions && (actions instanceof Array) && actions.length) {
+    if (typeof(type) === 'boolean' && type) {
+      actions = [ds.action.divider].concat(actions)
+    }
+
     var html = ''
     for (var i in actions) {
       var action = actions[i]

--- a/js/app/manager.js
+++ b/js/app/manager.js
@@ -112,37 +112,11 @@ ds.manager =
     }
 
     /**
-     * Return a context object based on the current URL.
-     */
-    self.location_context = function(context) {
-      var context = context || {}
-      var params = URI(window.location).query(true)
-      var variables = {}
-
-      context.from = params.from || '-3h'
-      context.until = params.until
-
-      for (var key in params) {
-        /* compatibility w/gdash params */
-        if (key.indexOf('p[') == 0) {
-          var name = key.slice(2, -1)
-          variables[name] = params[key]
-        } else {
-          variables[key] = params[key]
-        }
-      }
-      context.variables = variables
-      context.params = params
-
-      return context
-    }
-
-    /**
      * Set up us the API call.
      */
     self._prep_url = function(base_url, options) {
       var url = URI(base_url).setQuery('rendering', true)
-      var context = self.location_context(url.query(true))
+      var context = ds.context(url.query(true))
 
       context.from = options.from || context.from
       context.until = context.until || options.until
@@ -239,7 +213,7 @@ ds.manager =
       item.visit(function(i) {
         var query = item.query_override || item.query
         if (query && query.is_query) {
-          query.load({}, true)
+          query.load()
         }
       })
       ds.app.refresh_mode()
@@ -308,7 +282,7 @@ ds.manager =
       }
 
       $('#' + dashboard.definition.item_id).replaceWith(dashboard.render())
-      dashboard.render_templates(self.location_context().variables)
+      dashboard.render_templates(ds.context().variables)
       dashboard.load_all()
 
       if ((transform.transform_type === 'presentation') && (ds.app.current_mode != ds.app.Mode.EDIT)) {

--- a/js/core.js
+++ b/js/core.js
@@ -6,6 +6,33 @@ ds.edit = ds.edit || {}
 ds.edit.properties = ds.edit.properties || {}
 
 /**
+ * Return a context object based on the current URL.
+ */
+ds.context = function(context) {
+  context = context || {}
+  var params = URI(window.location).query(true)
+  var variables = {}
+
+  context.from = params.from || '-3h'
+  context.until = params.until
+
+  for (var key in params) {
+    /* compatibility w/gdash params */
+    if (key.indexOf('p[') == 0) {
+      var name = key.slice(2, -1)
+      variables[name] = params[key]
+    } else {
+      variables[key] = params[key]
+    }
+  }
+  context.variables = variables
+  context.params = params
+
+  return context
+}
+
+
+/**
  * Helper function to (potentially) render a template with a given
  * context object. If the string does not contain any handlebars tags,
  * it will be returned as-is.

--- a/js/factory.js
+++ b/js/factory.js
@@ -4,6 +4,11 @@ ds.register_dashboard_item = function(item_type, descriptor) {
     descriptor.template = Handlebars.compile(descriptor.template)
   }
 
+  if (descriptor.actions && descriptor.actions.length) {
+    console.log('Registering item actions')
+    ds.actions.register(item_type, descriptor.actions)
+  }
+
   var props = (descriptor.interactive_properties || []).map(function(p) {
                 if (typeof(p) === 'string') {
                   var prop = ds.property.get(p)

--- a/js/models/dashboard-items/timeshift_summation_table.js
+++ b/js/models/dashboard-items/timeshift_summation_table.js
@@ -9,6 +9,9 @@
  */
 ds.register_dashboard_item('timeshift_summation_table', {
 
+  /**
+   * Definition of the model object.
+   */
   constructor: function(data) {
     'use strict'
 
@@ -26,6 +29,7 @@ ds.register_dashboard_item('timeshift_summation_table', {
       if (self.query && self.query.is_query) {
         self.query_override =
           self.query.join(self.query.shift(self.shift)).set_name(self.item_id + '_shifted')
+        self.query_override.render_templates(ds.context().variables)
       }
     }
 
@@ -39,6 +43,8 @@ ds.register_dashboard_item('timeshift_summation_table', {
     self.on('change:query', function(e) {
       update_query()
     }).on('change:dashboard', function(e) {
+      update_query()
+    }).on('change:shift', function(e) {
       update_query()
     })
     ds.models.item.init(self, data)
@@ -55,6 +61,10 @@ ds.register_dashboard_item('timeshift_summation_table', {
     return self
   },
 
+  /**
+   * Handler to update the rendered DOM once the data query has been
+   * evaluated.
+   */
   data_handler: function(query, item) {
     var body = $('#' + item.item_id + ' tbody')
     var now  = query.data[0].summation
@@ -96,5 +106,52 @@ ds.register_dashboard_item('timeshift_summation_table', {
     'query',
     'shift',
     { id: 'css_class', category: 'base' }
+  ],
+
+  /**
+   * Additional actions specific to this presentation type to be added
+   * to the presentation actions menu.
+   */
+  actions: [
+    ds.action({
+      name:    'timeshift_1h',
+      display: '1 Hour Ago',
+      icon:    'fa fa-clock-o',
+      handler: function(action, item) {
+        item.shift = '1h'
+        ds.manager.update_item_view(item)
+      }
+    }),
+    ds.action({
+      name:    'timeshift_1d',
+      display: '1 Day Ago',
+      icon:    'fa fa-clock-o',
+      handler: function(action, item) {
+        item.shift = '1d'
+        ds.manager.update_item_view(item)
+      }
+    }),
+    ds.action({
+      name:    'timeshift_1w',
+      display: '1 Week Ago',
+      icon:    'fa fa-clock-o',
+      handler: function(action, item) {
+        item.shift = '1w'
+        ds.manager.update_item_view(item)
+      }
+    }),
+    ds.action({
+      name:    'timeshift_user_input',
+      display: 'Pick interval...',
+      icon:    'fa fa-clock-o',
+      handler: function(action, item) {
+        bootbox.prompt("Enter a time shift interval", function(result) {
+          if (result) {
+            item.shift = result
+            ds.manager.update_item_view(item)
+          }
+        })
+      }
+    })
   ]
 })

--- a/templates/_ds-action-menu.hbs
+++ b/templates/_ds-action-menu.hbs
@@ -6,5 +6,6 @@
   </button>
   <ul class="dropdown-menu dropdown-menu-right ds-action-menu" role="menu">
     {{actions 'presentation-actions'}}
+    {{actions item.item_type true}}
   </ul>
 </div>


### PR DESCRIPTION
- Adds a generic ability to augment the presentation actions menu with
  item_type-specific actions.
- Adds specific items to change the interval on
  `timeshift_summation_table` (issue #217)
- Dashboard item descriptors passed to `ds.register_dashboard_item()`
  can now have an `actions` attribute with the custom actions
