### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:precise
+
+RUN apt-get update
+RUN apt-get install -y python-pip python-dev wget ca-certificates && apt-get clean
+
+RUN wget -O - http://s3pository.heroku.com/node/v0.10.29/node-v0.10.29-linux-x64.tar.gz | tar xz -C /usr/local --strip-components 1
+RUN /usr/local/bin/npm install -g grunt-cli
+
+ADD . /app
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+RUN pip install -r dev-requirements.txt
+RUN npm install
+RUN grunt
+
+RUN invoke initdb
+RUN invoke json.import 'demo/*'
+
+EXPOSE 5000
+CMD invoke run

--- a/tessera/config.py
+++ b/tessera/config.py
@@ -1,10 +1,12 @@
+from os import getenv
+
 DEBUG                      = True
 SECRET_KEY                 = 'REPLACE ME'
 DEFAULT_FROM_TIME          = '-3h'
 DEFAULT_THEME              = 'light'
 DASHBOARD_APPNAME          = 'Tessera'
 SQLALCHEMY_DATABASE_URI    = 'sqlite:///tessera.db'
-GRAPHITE_URL               = 'http://localhost:8080'
+GRAPHITE_URL               = getenv('GRAPHITE_URL', 'http://localhost:8080')
 SERVER_ADDRESS             = '0.0.0.0'
 SERVER_PORT                = 5000
 INTERACTIVE_CHARTS_DEFAULT = True


### PR DESCRIPTION
Adding a Dockerfile for "let's have a quick look" support. Uses the dev setup as documented in the wiki. I pushed my image to the index, but I don't intend to maintain it. I suggest you build your own image.

`docker run -t -i -e GRAPHITE_URL=http://graphite.example.com -p 5000:5000 pschultz/tessera`
