### PR TITLE
Add a handlebars helper to list dashboards by tag in Markdown

### DIFF
--- a/js/app/helpers.js
+++ b/js/app/helpers.js
@@ -153,3 +153,29 @@ Handlebars.registerHelper('actions', function(category, type) {
     return ''
   }
 })
+
+Handlebars.registerHelper('dashboards-tagged', function(tag) {
+  var markdown = ''
+  $.ajax({
+    url: '/api/dashboard/tagged/' + tag,
+    type: 'GET',
+    async: false,
+    success: function(data) {
+      for (var i in data.dashboards) {
+        var d = data.dashboards[i]
+        markdown += '  * ['
+        if (d.category && d.category !== '') {
+          markdown += d.category + ': '
+        }
+        markdown += d.title + ']('
+        markdown += d.view_href + ')\n'
+      }
+    },
+    error: function() {
+      var error = 'Unable to retrieve list of dashboards tagged "' + tag + '"'
+      ds.manager.warning(error)
+      markdown = error
+    }
+  })
+  return new Handlebars.SafeString(markdown)
+})


### PR DESCRIPTION
Implements issue #279.

This adds a new handlebars helper which produces a Markdown-formatted list of links to all dashboards with a given tag. This can help in building hyperlinked dashboards. 
### Example

``` markdown
### Demos
{{dashboards-tagged "demo"}}
```

Produces:

``` markdown
### Demos

* [Demo: Gallery](/dashboards/1/gallery)
* [Demo: Random Data](/dashboards/2/random-data)
```
