### PR TITLE
Streamline the API

### DIFF
--- a/js/app/helpers.js
+++ b/js/app/helpers.js
@@ -161,8 +161,8 @@ Handlebars.registerHelper('dashboards-tagged', function(tag) {
     type: 'GET',
     async: false,
     success: function(data) {
-      for (var i in data.dashboards) {
-        var d = data.dashboards[i]
+      for (var i in data) {
+        var d = data[i]
         markdown += '  * ['
         if (d.category && d.category !== '') {
           markdown += d.category + ': '

--- a/js/app/manager.js
+++ b/js/app/manager.js
@@ -151,7 +151,7 @@ ds.manager =
         }).error(function(xhr, status, error) {
           self.error('Error loading dashboard. ' + error)
         }).done(function(data) {
-          var dashboard = ds.models.dashboard(data.dashboards[0])
+          var dashboard = ds.models.dashboard(data)
           holder.dashboard = dashboard
 
           if (data.preferences.renderer && ds.charts[data.preferences.renderer]) {
@@ -306,7 +306,7 @@ ds.manager =
     // here
     self.toggle_interactive_charts = function() {
         $.get('/api/preferences', function(data) {
-            var setting = !data.preferences.interactive
+            var setting = !data.interactive
             var dashboard_url = URI(self.current.url)
             var window_url = URI(window.location)
 
@@ -482,12 +482,12 @@ ds.manager =
     self.duplicate = function(href, handler) {
         // Get dashboard
         $.get(href, function(data) {
-            var dashboard = data.dashboards[0]
+            var dashboard = data
             dashboard.title = 'Copy of ' + dashboard.title
 
             // Get definition
             $.get(href + '/definition', function(data) {
-                dashboard.definition = data.definition
+                dashboard.definition = data
                 // Duplicate dashboard
                 $.ajax({
                     type: 'POST',

--- a/tessera/_version.py
+++ b/tessera/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 0)
+__version_info__ = (0, 4, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tessera/templates/dashboard-list.html
+++ b/tessera/templates/dashboard-list.html
@@ -61,7 +61,7 @@
       var path = '/api/dashboard/?sort={{ctx.get('sort', 'created')}}&order={{ctx.get('order', 'desc')}}'
     {% endif %}
     ds.manager.list(path, function(data) {
-      var rendered = ds.templates.listing.dashboard_list(data)
+      var rendered = ds.templates.listing.dashboard_list({ dashboards: data })
       $("#ds-dashboard-main-listing").html(rendered)
     })
 
@@ -69,7 +69,7 @@
       dataType: 'json',
       url: '/api/tag/'
     }).done(function(data) {
-      var context = { tags: data.tags }
+      var context = { tags: data }
     {% if tag %}
       context.tag = '{{ tag }}'
     {% endif %}

--- a/tessera/templates/index.html
+++ b/tessera/templates/index.html
@@ -53,9 +53,9 @@
   <script>
    /* Load featured dashboard list */
    ds.manager.list('/api/dashboard/tagged/featured', function(data) {
-     if (data.dashboards && data.dashboards.length) {
+     if (data && data.length) {
        $("#ds-featured-dashboards").show()
-       $("#ds-dashboard-featured-listing").html(ds.templates.listing.dashboard_list(data))
+       $("#ds-dashboard-featured-listing").html(ds.templates.listing.dashboard_list({dashboards: data}))
      }
    })
 
@@ -63,8 +63,8 @@
     * select one of them at random to display at the top of the
     * page. */
    ds.manager.list('/api/dashboard/tagged/featured-billboard', function(data) {
-     if (data.dashboards && data.dashboards.length > 0) {
-       var dashboard = data.dashboards[Math.floor(Math.random() * data.dashboards.length)]
+     if (data && data.length > 0) {
+       var dashboard = data[Math.floor(Math.random() * data.length)]
        ds.manager.load(dashboard.href, '.ds-featured-dashboard', {
          interactive: true,
          from: '-3h'


### PR DESCRIPTION
The API originally followed the pattern of Urban Airship’s public API
v3, which included a wrapper object in each response, which provides
room for status and extra metadata.  However, it makes the inputs &
outputs asymmetric. This change strips that out, just using the raw
entity representations.

The main benefit? We can now easily import/export via the API with
curl, or similar simple HTTP tools. Dashboards can be copied from one
instance of Tessera to another simply by piping one curl command to
another.
