### PR TITLE
Update the range indicator in display mode

### DIFF
--- a/js/app/handlers/display-mode.js
+++ b/js/app/handlers/display-mode.js
@@ -1,5 +1,12 @@
 ds.app.add_mode_handler('display', {
   enter: function() {
+    /* Make sure the fullscreen range indicator is correct */
+    var range       = ds.manager.get_time_range()
+    var description = ds.manager.getRangeDescription(range.from);
+    if ( description ) {
+      $("a.ds-fullscreen-range-indicator").text(description);
+    }
+    /* Update the header to match the dashboard if it's fluid */
     var fluid = false
     ds.manager.current.dashboard.definition.visit(function(item) {
       if (item.layout === 'fluid')

--- a/js/app/manager.js
+++ b/js/app/manager.js
@@ -353,6 +353,14 @@ ds.manager =
        Time range and auto-refresh
        ----------------------------------------------------------------------------- */
 
+    self.get_time_range = function() {
+      var context = ds.context(URI(window.location).query(true))
+      return {
+        from: context.from || ds.config.DEFAULT_FROM_TIME,
+        until: context.until
+      }
+    }
+
     self.set_time_range = function(from, until) {
         var uri = URI(window.location)
         from


### PR DESCRIPTION
On first load, the range indicator in display mode has been incorrect.
Added an easy accessor for getting the current time range, and update
the display on entering display mode.
