### PR TITLE
graphite_url is not in /

### DIFF
--- a/js/models/data/Query.js
+++ b/js/models/data/Query.js
@@ -50,7 +50,6 @@ ds.models.data.Query = function(data) {
     var uri = URI(options.base_url || ds.config.GRAPHITE_URL)
     var path = uri.path() + (/\/$/.test(uri.path()) ? 'render' : '/render')
     var url = uri.path(path)
-              .path('/render')
               .setQuery('format', options.format || 'png')
               .setQuery('from', options.from || ds.config.DEFAULT_FROM_TIME || self.DEFAULT_FROM_TIME)
               .setQuery('tz', ds.config.DISPLAY_TIMEZONE)


### PR DESCRIPTION
i have graphite url like this http://localhost/graphite, /graphite part gets overriden by .path(/render) statement.
the pach fixes it, by add /?render to GRAPHITE_URL path
