### PR TITLE
Fix the axis ticks for larger tick sizes

### DIFF
--- a/js/charts/flot.js
+++ b/js/charts/flot.js
@@ -29,6 +29,15 @@ ds.charts.flot =
         xaxis: {
           mode: "time",
           tickFormatter: function(value) {
+            // Take care of time series axis
+            if(axis.tickSize && axis.tickSize.length === 2) {
+              if(axis.tickSize[1] === 'year' && axis.tickSize[0] >= 1)
+                return moment(value).tz(ds.config.DISPLAY_TIMEZONE).format('YYYY')
+              if(axis.tickSize[1] === 'month' && axis.tickSize[0] >= 1 || axis.tickSize[1] === 'year')
+                return moment(value).tz(ds.config.DISPLAY_TIMEZONE).format('MM-\'YY')
+              if(axis.tickSize[1] === 'day' && axis.tickSize[0] >= 1 || axis.tickSize[1] === 'month')
+                return moment(value).tz(ds.config.DISPLAY_TIMEZONE).format('MM/DD')
+            }
             return moment(value).tz(ds.config.DISPLAY_TIMEZONE).format('h:mm A')
           },
           tickColor: theme_colors.minorGridLineColor,


### PR DESCRIPTION
When having larger axis ticks (for longer periods, this could e.g. be one week) the axis ticks show meaningless values (weekday and time of day). Print appropriate axis ticks depending on the actual axis tick size.
