### PR TITLE
Fixing "quick start" instructions to include db init

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ GRAPHITE_URL="http://graphite.example.com"
 SECRET_KEY="adf71812-9d57-88d3-dfe8-1e9860d2b7ab"
 ```
 
+Initialize the sqlite db (possibly requires sudo):
+
+```
+tessera-init
+```
+
 Then launch the service:
 
 ```


### PR DESCRIPTION
Current quick start instructions leave you with an install that will start, but throw a bunch of errors as the DB has not been initialized. The instructions on the website also need major updates, referring to a command, "inv" that does not seem to exist.
